### PR TITLE
[PR] Gradle 스크립트에서 절대 경로를 사용합니다. (Core Gradle Kts)

### DIFF
--- a/gradle-scripts/core.gradle.kts
+++ b/gradle-scripts/core.gradle.kts
@@ -1,4 +1,4 @@
-val coreDir = "../core-modules"
+val coreDir = "${rootProject.projectDir}/core-modules"
 
 include(
     ":nettee:jpa-core",


### PR DESCRIPTION
Resolve #7