### PR TITLE
[PR] Disable `bootJar` as a Default, and Propagate Common Module via Sub-Projects

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -1,3 +1,5 @@
+import org.springframework.boot.gradle.tasks.bundling.BootJar
+
 plugins {
     java
     id("java-library")
@@ -8,6 +10,10 @@ plugins {
 allprojects {
     group = "nettee"
     version = "0.0.1-SNAPSHOT"
+
+    tasks.withType<BootJar> {
+        enabled = false
+    }
 }
 
 subprojects {

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -28,4 +28,8 @@ subprojects {
         mavenCentral()
         maven { url = uri("https://jitpack.io") }
     }
+
+    dependencies {
+        api(project(":common"))
+    }
 }


### PR DESCRIPTION
### Issues

Resolves #28 
Resolves #29 

- #28 
- #29 