### PR TITLE
[PR] Board API 모듈 및 도메인, 조회 모델, 에러코드

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -31,5 +31,7 @@ subprojects {
 
     dependencies {
         api(project(":common"))
+        compileOnly("org.projectlombok:lombok")
+        compileOnly("org.springframework:spring-web")
     }
 }

--- a/services/board/api/domain/src/main/java/nettee/board/domain/Board.java
+++ b/services/board/api/domain/src/main/java/nettee/board/domain/Board.java
@@ -1,0 +1,45 @@
+package nettee.board.domain;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import nettee.board.domain.type.BoardStatus;
+
+import java.time.Instant;
+import java.util.Objects;
+
+@Getter
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class Board {
+
+    private Long id;
+
+    private String title;
+    private String content;
+
+    private BoardStatus status;
+    private Instant createdAt;
+    private Instant updatedAt;
+
+    @Builder(
+        builderClassName = "updateBoardBuilder",
+        builderMethodName = "prepareUpdate",
+        buildMethodName = "update"
+    )
+    public void update(String title, String content) {
+        Objects.requireNonNull(title, "Title cannot be null");
+        Objects.requireNonNull(content, "content cannot be null");
+
+        this.title = title;
+        this.content = content;
+        this.updatedAt = Instant.now();
+    }
+
+    public void softDelete() {
+        this.status = BoardStatus.REMOVED;
+    }
+
+}

--- a/services/board/api/domain/src/main/java/nettee/board/domain/Board.java
+++ b/services/board/api/domain/src/main/java/nettee/board/domain/Board.java
@@ -15,7 +15,7 @@ import java.util.Objects;
 @AllArgsConstructor
 public class Board {
 
-    private Long id;
+    private String id;
 
     private String title;
     private String content;

--- a/services/board/api/domain/src/main/java/nettee/board/domain/type/BoardStatus.java
+++ b/services/board/api/domain/src/main/java/nettee/board/domain/type/BoardStatus.java
@@ -1,0 +1,19 @@
+package nettee.board.domain.type;
+
+import java.util.EnumSet;
+import java.util.Set;
+
+public enum BoardStatus {
+
+    PENDING,
+    ACTIVE,
+    SUSPENDED,
+    REMOVED;
+
+    private static final Set<BoardStatus> GENERAL_QUERY_STATUS = EnumSet.of(ACTIVE, SUSPENDED);
+
+    public static Set<BoardStatus> getGeneralQueryStatus() {
+       return GENERAL_QUERY_STATUS;
+    }
+
+}

--- a/services/board/api/exception/src/main/java/nettee/board/exception/BoardErrorCode.java
+++ b/services/board/api/exception/src/main/java/nettee/board/exception/BoardErrorCode.java
@@ -1,0 +1,67 @@
+package nettee.board.exception;
+
+import letsdev.common.exception.support.ErrorCode;
+import org.springframework.http.HttpStatus;
+
+import java.util.Map;
+import java.util.function.Supplier;
+
+import static org.springframework.http.HttpStatus.*;
+
+public enum BoardErrorCode implements ErrorCode {
+    BOARD_ALREADY_EXISTS(CONFLICT),
+    BOARD_NOT_FOUND(NOT_FOUND),
+    BOARD_GONE(GONE),
+    BOARD_FORBIDDEN(FORBIDDEN),
+    BOARD_DEFAULT(INTERNAL_SERVER_ERROR);
+
+    private static final String NAMESPACE = "board.error";
+
+    private final String messageKey;
+    private final HttpStatus status;
+
+    BoardErrorCode(HttpStatus status) {
+        this.messageKey = NAMESPACE + "." + this.name();
+        this.status = status;
+    }
+
+    @Override
+    public HttpStatus httpStatus() {
+        return status;
+    }
+
+    @Override
+    public String message() {
+        return messageKey;
+    }
+
+    @Override
+    public RuntimeException exception() {
+        return new BoardException(this);
+    }
+
+    @Override
+    public RuntimeException exception(Throwable cause) {
+        return new BoardException(this, cause);
+    }
+
+    @Override
+    public RuntimeException exception(Runnable action) {
+        return new BoardException(this, action);
+    }
+
+    @Override
+    public RuntimeException exception(Runnable action, Throwable cause) {
+        return new BoardException(this, action, cause);
+    }
+
+    @Override
+    public RuntimeException exception(Supplier<Map<String, Object>> payloadSupplier) {
+        return new BoardException(this, payloadSupplier);
+    }
+
+    @Override
+    public RuntimeException exception(Supplier<Map<String, Object>> payloadSupplier, Throwable cause) {
+        return new BoardException(this, payloadSupplier, cause);
+    }
+}

--- a/services/board/api/exception/src/main/java/nettee/board/exception/BoardException.java
+++ b/services/board/api/exception/src/main/java/nettee/board/exception/BoardException.java
@@ -1,0 +1,41 @@
+package nettee.board.exception;
+
+import letsdev.common.exception.support.CustomException;
+import letsdev.common.exception.support.ErrorCode;
+
+import java.util.Map;
+import java.util.function.Supplier;
+
+public class BoardException extends CustomException {
+    public BoardException(String message) {
+        super(message);
+    }
+
+    public BoardException(String message, Throwable cause) {
+        super(message, cause);
+    }
+
+    public BoardException(ErrorCode errorCode) {
+        super(errorCode);
+    }
+
+    public BoardException(ErrorCode errorCode, Throwable cause) {
+        super(errorCode, cause);
+    }
+
+    public BoardException(ErrorCode errorCode, Runnable action) {
+        super(errorCode, action);
+    }
+
+    public BoardException(ErrorCode errorCode, Runnable action, Throwable cause) {
+        super(errorCode, action, cause);
+    }
+
+    public BoardException(ErrorCode errorCode, Supplier<Map<String, Object>> payloadSupplier) {
+        super(errorCode, payloadSupplier);
+    }
+
+    public BoardException(ErrorCode errorCode, Supplier<Map<String, Object>> payloadSupplier, Throwable cause) {
+        super(errorCode, payloadSupplier, cause);
+    }
+}

--- a/services/board/api/readmodel/build.gradle.kts
+++ b/services/board/api/readmodel/build.gradle.kts
@@ -5,5 +5,5 @@ java {
 }
 
 dependencies {
-
+    api(project(":board:domain"))
 }

--- a/services/board/api/readmodel/src/main/java/nettee/board/readmodel/BoardReadModels.java
+++ b/services/board/api/readmodel/src/main/java/nettee/board/readmodel/BoardReadModels.java
@@ -1,0 +1,32 @@
+package nettee.board.readmodel;
+
+import lombok.Builder;
+import nettee.board.domain.type.BoardStatus;
+
+import java.time.Instant;
+
+public final class BoardReadModels {
+
+    private BoardReadModels() {}
+
+    @Builder
+    public record BoardDetail(
+            String id,
+            String title,
+            String content,
+            BoardStatus status,
+            Instant createdAt,
+            Instant updatedAt
+    ) {
+    }
+
+    @Builder
+    public record BoardSummary(
+            String id,
+            String title,
+            BoardStatus status,
+            Instant createdAt,
+            Instant updatedAt
+    ) {
+    }
+}


### PR DESCRIPTION
### Issues

Resolves #36 
Resolves #37 
Resolves #38 
Resolves #39 

- #36 
- #37 
- #38 
- #39 

## Additional Notes

- 도메인의 id 타입은 `String`을 유지합니다.
- 에러 코드는 message 대신 message key를 반환합니다. (추후 다국어)
- 조회 모델의 id 타입은 `String`을 유지합니다.
- 조회 모델 모듈은 도메인 모듈을 사용합니다.
