### PR TITLE
[PR] Board Entity Status Converter에서 `BoardEntityStatus` 객체가 null이면 정수로 변환하지 않고 null을 반환합니다.

### DIFF
--- a/services/board/driven/rdb/src/main/java/nettee/board/persistence/entity/type/BoardEntityStatusConverter.java
+++ b/services/board/driven/rdb/src/main/java/nettee/board/persistence/entity/type/BoardEntityStatusConverter.java
@@ -8,7 +8,7 @@ public class BoardEntityStatusConverter implements AttributeConverter<BoardEntit
 
     @Override
     public Integer convertToDatabaseColumn(BoardEntityStatus status) {
-        return status.getCode();
+        return status != null ? status.getCode() : null;
     }
 
     @Override


### PR DESCRIPTION
### Issues

- Resolves #81 