### PR TITLE
[PR] Monolith Main Runner 실행을 위해 로깅 라이브러리 충돌을 해결하고, 원활한 배포 준비를 위해 bootJar를 활성화합니다.

### DIFF
--- a/monolithic/main-runner/build.gradle.kts
+++ b/monolithic/main-runner/build.gradle.kts
@@ -13,6 +13,15 @@ java {
     }
 }
 
+configurations {
+    compileOnly {
+        extendsFrom(configurations.annotationProcessor.get())
+    }
+    configureEach {
+        exclude(group = "org.springframework.boot", module = "spring-boot-starter-logging")
+    }
+}
+
 dependencies {
     val bom = dependencyManagement.importedProperties
 

--- a/monolithic/main-runner/build.gradle.kts
+++ b/monolithic/main-runner/build.gradle.kts
@@ -1,5 +1,6 @@
 import org.jetbrains.kotlin.gradle.tasks.KotlinCompile
 import org.jetbrains.kotlin.gradle.dsl.JvmTarget
+import org.springframework.boot.gradle.tasks.bundling.BootJar
 
 plugins {
     kotlin("jvm") version "1.9.22"
@@ -88,4 +89,8 @@ tasks.withType<JavaCompile> {
 
 tasks.named<JavaExec>("bootRun") {
     jvmArgs("--enable-preview")
+}
+
+tasks.withType<BootJar> {
+    enabled = true
 }


### PR DESCRIPTION
### Issues

- #82 
- #83 